### PR TITLE
fix: adding concurrency check on Tracetest constructor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.21
 
       - name: Install xk6
         run: go install go.k6.io/xk6/cmd/xk6@latest

--- a/modules/tracetest/tracetest.go
+++ b/modules/tracetest/tracetest.go
@@ -24,6 +24,7 @@ type Tracetest struct {
 	logger          logrus.FieldLogger
 	client          *openapi.APIClient
 	apiOptions      models.ApiOptions
+	mutex           sync.Mutex
 }
 
 func New() *Tracetest {
@@ -33,6 +34,7 @@ func New() *Tracetest {
 		processedBuffer: sync.Map{},
 		logger:          logger.WithField("component", "xk6-tracetest-tracing"),
 		client:          NewAPIClient(models.ApiOptions{}),
+		mutex:           sync.Mutex{},
 	}
 
 	duration := 1 * time.Second
@@ -52,6 +54,9 @@ func (t *Tracetest) UpdateFromConfig(config models.OutputConfig) {
 }
 
 func (t *Tracetest) Constructor(call goja.ConstructorCall) *goja.Object {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
 	rt := t.Vu.Runtime()
 	apiOptions, err := models.NewApiOptions(t.Vu, call.Argument(0))
 	if err != nil {


### PR DESCRIPTION
This PR aims to fix a concurrency problem that we have when we execute load testing with this plugin, as described on https://github.com/kubeshop/xk6-tracetest/issues/5

Steps to recreate the problem:

1. Clone [Tracetest](https://github.com/kubeshop/tracetest)
2. Go to `testing/load` folder and execute `./run.bash`
3. After k6 start to run, interrupt the process with a `Ctrl+C`
4. Try to run the command `./k6 run load-test.js -o xk6-tracetest`
5. The error should appear as k6 starts

Steps to test this PR:
1. Clone [Tracetest](https://github.com/kubeshop/tracetest)
2. Go to `testing/load` folder and change line 37 of `./run.bash` ([here](https://github.com/kubeshop/tracetest/blob/main/testing/load/run.bash#L37)), from
```sh
xk6 build v0.42.0 --with github.com/kubeshop/xk6-tracetest \
``` 
to 
```sh
xk6 build v0.42.0 --with github.com/kubeshop/xk6-tracetest@v0.1.4-rc.1 \
```
3. Run `./run.bash` and interrupt k6 with `Ctrl+C`
4. Try to run the command `./k6 run load-test.js -o xk6-tracetest`
5. The test should continue to execute successfully

## Changes

- Added a mutex on Tracetest `Constructor`

## Fixes

- https://github.com/kubeshop/xk6-tracetest/issues/5

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
